### PR TITLE
VWDExpress 2010 Error Fix

### DIFF
--- a/examples/apps/CSharp/OpenF2.Examples.CSharp.csproj
+++ b/examples/apps/CSharp/OpenF2.Examples.CSharp.csproj
@@ -7,7 +7,7 @@
     </ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{94C1DEC6-42C3-47B4-A4F6-105BB914DA3D}</ProjectGuid>
-    <ProjectTypeGuids>{E53F8FEA-EAE0-44A6-8774-FFD645390401};{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OpenF2.Examples.CSharp</RootNamespace>


### PR DESCRIPTION
IN VWD Express 2010, this error manifests due to having 3+ GUIDs in the
ProjecTypeGuids XML node.

Specific Error Messages:
On Open: One or more projects in the solution were not loaded correctly.
Please see Output Window for details.

After open, in Output: The project type is not supported by this
installation.
