### PR TITLE
updates required for upload to npmjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "F2",
 	"description": "An open framework for the financial services industry.",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"main": "dist/f2.debug",
 	"keywords": [
 		"openf2"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "F2",
 	"description": "An open framework for the financial services industry.",
 	"version": "1.4.2",
+	"main": "dist/f2.debug",
 	"keywords": [
 		"openf2"
 	],
@@ -39,6 +40,10 @@
 		"underscore": "^1.8.3",
 		"yuidocjs": "~0.3.44"
 	},
+	"files":[
+		"dist/*",
+		"ThirdPartyMaterial.md"
+	],
 	"engines": {
 		"node": ">=0.10"
 	},


### PR DESCRIPTION
These updates should make it such that we can upload F2 to npmjs.org so that the library could be npm installed by users.  ES6/webpack usage would look like `import 'F2';`.  